### PR TITLE
Urlencode path for reading to allow foreign characters

### DIFF
--- a/src/Adapter/BunnyCdnAdapter.php
+++ b/src/Adapter/BunnyCdnAdapter.php
@@ -319,7 +319,7 @@ class BunnyCdnAdapter implements AdapterInterface
         return [
             'type' => 'file',
             'path' => $path,
-            'stream' => fopen($this->apiUrl . $path . '?AccessKey=' . $this->apiKey, 'rb'),
+            'stream' => fopen($this->apiUrl . $this->urlencodePath($path) . '?AccessKey=' . $this->apiKey, 'rb'),
         ];
     }
 


### PR DESCRIPTION
Same way as it's done in writeStream we have to urlencodePath in readStream to allow foreign characters.

https://github.com/FriendsOfShopware/FroshPlatformBunnycdnMediaStorage/blob/master/src/Adapter/BunnyCdnAdapter.php#L81