### PR TITLE
* fix url encoding for read operations

### DIFF
--- a/src/Adapter/BunnyCdnAdapter.php
+++ b/src/Adapter/BunnyCdnAdapter.php
@@ -297,7 +297,7 @@ class BunnyCdnAdapter implements AdapterInterface
      */
     public function read($path)
     {
-        if (!$object = $this->readStream($path)) {
+        if (!$object = $this->readStream($this->urlencodePath($path))) {
             return false;
         }
         $object['contents'] = stream_get_contents($object['stream']);


### PR DESCRIPTION
For some reason reading fails if the $path is not properly encoded