### PR TITLE
PHP 8 compatibilty: get_headers requires requires bool as second param

### DIFF
--- a/src/Adapter/BunnyCdnAdapter.php
+++ b/src/Adapter/BunnyCdnAdapter.php
@@ -369,7 +369,11 @@ class BunnyCdnAdapter implements AdapterInterface
      */
     public function getMetadata($path)
     {
-        $headers = get_headers($this->apiUrl . $this->urlencodePath($path) . '?AccessKey=' . $this->apiKey, true);
+        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
+            $headers = get_headers($this->apiUrl . $this->urlencodePath($path) . '?AccessKey=' . $this->apiKey, true);
+        } else {
+            $headers = get_headers($this->apiUrl . $this->urlencodePath($path) . '?AccessKey=' . $this->apiKey, 1);
+        }
         if (mb_strpos($headers[0], '200') === false) {
             return false;
         }


### PR DESCRIPTION
Hi guys,

We ran into some problems when we tried installing this plugin on a PHP 8 site. `\Frosh\BunnycdnMediaStorage\Adapter\BunnyCdnAdapter::getMetadata` passes an int as second param to `get_headers`, but in PHP 8 this is required to be a bool. 

See https://github.com/phpstan/php-8-stubs/blob/main/stubs/ext/standard/get_headers.php

This PR fixes this issue. Let me know if you have any questions.